### PR TITLE
[FEAT] 대시보드 구현

### DIFF
--- a/frontend/src/components/homepage/Login.jsx
+++ b/frontend/src/components/homepage/Login.jsx
@@ -10,7 +10,7 @@ export default function Login({ onBack, onSignUp }) {
   const navigate = useNavigate();
 
   const handleLogin = () => {
-    navigate("/classroom");
+    navigate("/dashboard");
   };
 
   return (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -27,4 +27,7 @@
   .input-field {
     @apply text-center text-2xl w-2/3 p-3 font-jetbrains bg-gray-200 outline-none text-letter;
   }
+  .dark-btn {
+    @apply bg-primary text-white rounded-lg border border-primary hover:bg-secondary hover:text-primary;
+  }
 }

--- a/frontend/src/pages/Classroom.jsx
+++ b/frontend/src/pages/Classroom.jsx
@@ -23,7 +23,7 @@ const Classroom = () => {
           강의실 1
         </div>
         <button
-          className="flex justify-center bg-primary text-2xl py-3 px-10 text-white rounded-lg border border-primary hover:bg-secondary hover:text-primary"
+          className="dark-btn bg-primary text-2xl py-3 px-10"
           onClick={handleClassStart}
         >
           {isTeacher ? "수업하기" : "수업듣기"}

--- a/frontend/src/pages/Classroom.jsx
+++ b/frontend/src/pages/Classroom.jsx
@@ -19,7 +19,7 @@ const Classroom = () => {
   return (
     <div className="flex flex-col h-screen w-full p-20 gap-8">
       <div className="flex flex-row w-full px-10 items-center justify-between">
-        <div className="flex justify-center text-3xl font-bold text-primary">
+        <div className="flex justify-center text-4xl font-bold text-primary">
           강의실 1
         </div>
         <button

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,7 @@
 import { useUser } from "../provider/UserContext";
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+import deleteIcon from "../assets/delete.png";
 
 function ClassroomCard({ name, content }) {
   const navigate = useNavigate();
@@ -46,8 +48,70 @@ function ClassroomList({ isTeacher }) {
   );
 }
 
+function AddClassroomModal({ isOpen, onClose }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-white p-8 rounded-lg w-96 relative">
+        <h2 className="text-xl font-bold mb-4 text-center">강의실 추가</h2>
+        <input
+          type="text"
+          className="w-full p-2 border border-gray-300 rounded-md mb-4"
+          placeholder="강의실 이름을 입력하세요"
+        />
+        <button className="w-full dark-btn p-2" onClick={onClose}>
+          개설하기
+        </button>
+        <button
+          className="p-1 rounded absolute top-2 right-2"
+          onClick={onClose}
+        >
+          <img src={deleteIcon} alt="delete" className="w-6 h-6" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EnterClassroomModal({ isOpen, onClose }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-white p-8 rounded-lg w-96 relative">
+        <h2 className="text-xl font-bold mb-4 text-center">강의실 입장</h2>
+        <input
+          type="text"
+          className="w-full p-2 border border-gray-300 rounded-md mb-4"
+          placeholder="강의실 코드를 입력하세요"
+        />
+        <button className="w-full dark-btn p-2" onClick={onClose}>
+          입장하기
+        </button>
+        <button
+          className="p-1 rounded absolute top-2 right-2"
+          onClick={onClose}
+        >
+          <img src={deleteIcon} alt="delete" className="w-6 h-6" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 const Dashboard = () => {
   const { isTeacher } = useUser();
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isEnterModalOpen, setIsEnterModalOpen] = useState(false);
+
+  const handleModalButtonClick = () => {
+    if (isTeacher) {
+      setIsAddModalOpen(true);
+    } else {
+      setIsEnterModalOpen(true);
+    }
+  };
 
   return (
     <div className="flex flex-col h-screen w-full p-20 gap-8">
@@ -56,13 +120,23 @@ const Dashboard = () => {
           칠드런 님의 강의
         </div>
         <button
-          className="flex justify-center bg-primary text-2xl py-3 px-10 text-white rounded-lg border border-primary hover:bg-secondary hover:text-primary"
-          // onClick={}
+          className="dark-btn text-2xl py-3 px-10"
+          onClick={() => handleModalButtonClick()}
         >
           {isTeacher ? "강의실 추가" : "강의실 입장"}
         </button>
       </div>
       <ClassroomList isTeacher={isTeacher} />
+
+      {/* 모달 컴포넌트 */}
+      <AddClassroomModal
+        isOpen={isAddModalOpen}
+        onClose={() => setIsAddModalOpen(false)}
+      />
+      <EnterClassroomModal
+        isOpen={isEnterModalOpen}
+        onClose={() => setIsEnterModalOpen(false)}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,70 @@
+import { useUser } from "../provider/UserContext";
+import { useNavigate } from "react-router-dom";
+
+function ClassroomCard({ name, content }) {
+  const navigate = useNavigate();
+  const handleClassroomClick = () => {
+    navigate(`/classroom`);
+  };
+  return (
+    <button
+      className="flex flex-row w-full px-32 py-4 items-center justify-between font-normal text-lg border-b hover:bg-gray-50"
+      onClick={handleClassroomClick}
+    >
+      <span className="font-bold">{name}</span>
+      <span>{content}</span>
+    </button>
+  );
+}
+
+function ClassroomList({ isTeacher }) {
+  const headerContent = isTeacher ? "강의실 코드" : "선생님";
+  const classrooms = isTeacher
+    ? [
+        { name: "강의실 1", content: "IX035J2" },
+        { name: "강의실 2", content: "PK123S1" },
+      ]
+    : [
+        { name: "강의실 1", content: "칠드런" },
+        { name: "강의실 2", content: "송정현" },
+      ];
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-row w-full px-32 py-2 items-center justify-between font-light rounded-lg bg-secondary text-letter">
+        <span>강의실 이름</span>
+        <span>{headerContent}</span>
+      </div>
+      {classrooms.map((classroom, index) => (
+        <ClassroomCard
+          key={index}
+          name={classroom.name}
+          content={classroom.content}
+        />
+      ))}
+    </div>
+  );
+}
+
+const Dashboard = () => {
+  const { isTeacher } = useUser();
+
+  return (
+    <div className="flex flex-col h-screen w-full p-20 gap-8">
+      <div className="flex flex-row w-full px-10 items-center justify-between">
+        <div className="flex justify-center text-4xl font-bold text-primary">
+          칠드런 님의 강의
+        </div>
+        <button
+          className="flex justify-center bg-primary text-2xl py-3 px-10 text-white rounded-lg border border-primary hover:bg-secondary hover:text-primary"
+          // onClick={}
+        >
+          {isTeacher ? "강의실 추가" : "강의실 입장"}
+        </button>
+      </div>
+      <ClassroomList isTeacher={isTeacher} />
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -3,6 +3,7 @@ import Home from "../pages/Home";
 import Classroom from "../pages/Classroom";
 import StudentIDE from "../pages/StudentIDE";
 import TeacherIDE from "../pages/TeacherIDE";
+import Dashboard from "../pages/Dashboard";
 
 const ideduRouter = createBrowserRouter([
   {
@@ -12,6 +13,10 @@ const ideduRouter = createBrowserRouter([
   {
     path: "/classroom",
     element: <Classroom />,
+  },
+  {
+    path: "/dashboard",
+    element: <Dashboard />,
   },
   {
     path: "/student-ide",


### PR DESCRIPTION
<!-- PR 제목은 핵심 변경 사항을 요약해주세요 -->
<!-- ex) feat: 캐스트 생성 기능 추가 -->

## #️⃣ 연관 이슈
<!-- 연관된 이슈 번호를 적어주세요-->
> related to #11 

## 📝 요약
<!-- 작업 내용을 요약해주세요. -->

- 유저 정보에 맞게 대시보드 로드
- 강의실 생성/입장 모달창 구현

## 📌 향후 계획
<!-- 향후 추가로 작업해야할 내용을 적어주세요. -->

- 강의실 고유키로 생성
- 강의실 고유 페이지 주소로 연결
- 강의실 생성/입장 백엔드 연동, 구현
- 유저 데이터 백엔드 연동

## 변경사항 상세
<!-- 변경되거나 새로 만든 부분에 대한 설명 -->
<img width="1181" alt="스크린샷 2025-03-05 오전 2 03 35" src="https://github.com/user-attachments/assets/e4d14324-235a-44b7-9643-375e5888e602" />
<img width="1162" alt="스크린샷 2025-03-05 오전 2 03 54" src="https://github.com/user-attachments/assets/9898b099-17d5-4011-bf50-f8d2c71404d1" />
<img width="449" alt="스크린샷 2025-03-05 오전 2 04 09" src="https://github.com/user-attachments/assets/db95dd69-1dd5-4a38-84bd-41f7c63d2e86" />


